### PR TITLE
Replaced innerHTML with innerText to escape HTML special characters (eg: '<' in #include <stdio.h>)

### DIFF
--- a/lib/textpanel.coffee
+++ b/lib/textpanel.coffee
@@ -34,7 +34,7 @@ class TextPanel
         @element.remove()
 
     setText: (text) ->
-        @text.innerHTML = text;
+        @text.innerText = text;
 
     showWelcomeText: (commands) ->
         message = "Type or select a word to lookup documentation.\n\n"


### PR DESCRIPTION
Characters like the `<` in man/pydoc output were treated as HTML by Atom so that the library names in C, for example, didn't show up since they were parsed as HTML tags