### PR TITLE
pydoc: python3 transition (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Automatically fetches documentation for word under text cursor. Updated as you type.
 
-By default it uses 'pydoc' to look up documentation for python, 'ri' for ruby, and 'man' for everything else. Other programs can be set up in the atom's settings dialog.
+By default it uses 'pydoc3' to look up documentation for python, 'ri' for ruby, and 'man' for everything else. Other programs can be set up in the atom's settings dialog.
 
 ![Screencast](http://zippy.gfycat.com/NaturalAgonizingBlueshark.gif)

--- a/lib/live-doc-viewer.js
+++ b/lib/live-doc-viewer.js
@@ -43,7 +43,7 @@ module.exports = {
                 },
                 program: {
                     type: 'string',
-                    default: 'pydoc',
+                    default: 'pydoc3',
                 },
                 program_arguments: {
                     type: 'string',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "live-doc-viewer",
   "main": "./lib/live-doc-viewer",
   "version": "1.1.1",
-  "description": "Fetch documentation for word under cursor automatically. Can use any command line program similar to 'pydoc' or 'man'.",
+  "description": "Fetch documentation for word under cursor automatically. Can use any command line program similar to 'pydoc3' or 'man'.",
   "keywords": [
     "documentation",
     "man pages",


### PR DESCRIPTION
Python2 reached end of life on Jan 1 2020.  Newer operating system
releases, like Ubuntu 20.04, do not have python2 installed by default
and installation of python2 will not install unversioned executables
like python or pydoc, instead only pydoc2, pydoc3, etc are available
for installation.  On these releases users will see an error message
"Failed to launch 'pydoc'.  Make sure it is installed and in your path"
however it is no longer installable.

This patch changes the python documentation executable from pydoc to
pydoc3.  With python2 reaching end of life and the uptake of python3
most users should see no negative impact, but for those users with just
python2 installed the error message will ask them to install pydoc3
which should be actionable and is reasonable.